### PR TITLE
Fix buttons in camera

### DIFF
--- a/app/(app)/camera.tsx
+++ b/app/(app)/camera.tsx
@@ -224,7 +224,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'space-around',
         alignItems: 'center',
-        paddingBottom: Platform.OS === 'ios' ? 20 : 40,
+        paddingBottom: Platform.OS === 'ios' ? 40 : 60,
         paddingHorizontal: 20,
     },
     controlButton: {
@@ -267,6 +267,7 @@ const styles = StyleSheet.create({
         paddingVertical: 20,
         paddingHorizontal: 16,
         backgroundColor: '#000',
+        paddingBottom: Platform.OS === 'ios' ? 40 : 60,
     },
     previewButton: {
         flex: 1,


### PR DESCRIPTION
This MR addresses an issue where the camera control buttons ("Take Photo" and "Flip Camera") and preview buttons ("Retake" and "Use Photo") were not visible during local testing due to overlapping with the device's bottom UI elements.